### PR TITLE
NEW Add ability to skip copying block.css to theme

### DIFF
--- a/_config/content-blocks.yml
+++ b/_config/content-blocks.yml
@@ -11,3 +11,5 @@ LeftAndMain:
     - content-blocks/js/main.js
 GridFieldAddNewMultiClass:
   showEmptyString: false
+ContentBlocksModule:
+  copy_css_to_theme: true

--- a/code/ContentBlocksModule.php
+++ b/code/ContentBlocksModule.php
@@ -64,6 +64,10 @@ class ContentBlocksModule extends DataExtension {
 	function requireDefaultRecords() {
 		parent::requireDefaultRecords();
 		
+		if (!Config::inst()->get('ContentBlocksModule', 'copy_css_to_theme')) {
+			return;
+		}
+		
 		// If css file does not exist on current theme, copy from module
 		$copyfrom = BASE_PATH . "/".CONTENTBLOCKS_MODULE_DIR."/css/block.css";
 		$theme = SSViewer::current_theme();


### PR DESCRIPTION
Copying the block.css file to a theme is a bit unnecessary (can be included from the module dir) and is frustrating if you've customised or included it some other way to your project